### PR TITLE
Add basic tests for (un)exempting selected users

### DIFF
--- a/test/activity-exemptions/activity-exemptions_test.js
+++ b/test/activity-exemptions/activity-exemptions_test.js
@@ -196,11 +196,11 @@ describe('activity-exemptions', function() {
 			flush(function() {
 				var checkbox = Polymer.dom(element.root).querySelector('d2l-checkbox').$$('input');
 				var items = Polymer.dom(element.root).querySelectorAll('.row-user');
-				var exemptButton = Polymer.dom(element.root).querySelectorAll('d2l-button')[1];
+				var unexemptButton = Polymer.dom(element.root).querySelectorAll('d2l-button')[1];
 
 				MockInteractions.tap(checkbox);
 				flush(function() {
-					exemptButton.addEventListener('click', function() {
+					unexemptButton.addEventListener('click', function() {
 						flush(function() {
 							expect(items.length).to.equal(4);
 							items.forEach(function(row) {
@@ -209,7 +209,7 @@ describe('activity-exemptions', function() {
 							done();
 						});
 					});
-					MockInteractions.tap(exemptButton);
+					MockInteractions.tap(unexemptButton);
 				});
 			});
 		});

--- a/test/activity-exemptions/activity-exemptions_test.js
+++ b/test/activity-exemptions/activity-exemptions_test.js
@@ -158,4 +158,60 @@ describe('activity-exemptions', function() {
 			});
 		});
 	});
+
+	describe('activity-exemptions (un)exempt buttons', function() {
+		beforeEach(function() {
+			element.data = [
+				{'Identifier': 1, 'FirstName':'Benjamin', 'LastName':'Liam', 'IsExempt':true},
+				{'Identifier': 2, 'FirstName':'Isabella', 'LastName':'Madison', 'IsExempt':false},
+				{'Identifier': 3, 'FirstName':'Ethan', 'LastName':'Avery', 'IsExempt':false},
+				{'Identifier': 4, 'FirstName':'David', 'LastName':'Aubrey', 'IsExempt':true}
+			];
+			element.toMap(element.data);
+		});
+
+		it('should mark users exempt', function(done) {
+			flush(function() {
+				var checkbox = Polymer.dom(element.root).querySelector('d2l-checkbox').$$('input');
+				var items = Polymer.dom(element.root).querySelectorAll('.row-user');
+				var exemptButton = Polymer.dom(element.root).querySelectorAll('d2l-button')[0];
+
+				MockInteractions.tap(checkbox);
+				flush(function() {
+					exemptButton.addEventListener('click', function() {
+						flush(function() {
+							expect(items.length).to.equal(4);
+							items.forEach(function(row) {
+								expect(row.querySelector('activity-exemptions-exemptstatus').data.IsExempt).to.be.true;
+							}, this);
+							done();
+						});
+					});
+					MockInteractions.tap(exemptButton);
+				});
+			});
+		});
+
+		it('should mark users unexempt', function(done) {
+			flush(function() {
+				var checkbox = Polymer.dom(element.root).querySelector('d2l-checkbox').$$('input');
+				var items = Polymer.dom(element.root).querySelectorAll('.row-user');
+				var exemptButton = Polymer.dom(element.root).querySelectorAll('d2l-button')[1];
+
+				MockInteractions.tap(checkbox);
+				flush(function() {
+					exemptButton.addEventListener('click', function() {
+						flush(function() {
+							expect(items.length).to.equal(4);
+							items.forEach(function(row) {
+								expect(row.querySelector('activity-exemptions-exemptstatus').data.IsExempt).to.be.false;
+							}, this);
+							done();
+						});
+					});
+					MockInteractions.tap(exemptButton);
+				});
+			});
+		});
+	});
 });


### PR DESCRIPTION
PR adds two simple tests to make sure that the exempt and unexempt buttons work.

The general flow is select all the users, click the button, and then verify that the `activity-exemptions-exemptstatus` component has had `data.IsExempt` set correspondingly.