### PR TITLE
Fixing the reference to the sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: run publish:cdn
         env:
           VERSION: ${{ steps.incremental-release.outputs.VERSION }}
-          GIT_COMMIT: ${{ env.GITHUB_SHA }}
+          GIT_COMMIT: ${{ github.sha }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}


### PR DESCRIPTION
Turns out that this is the right way to refer to the sha value

Documentation:
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions