### PR TITLE
move polymer-cli to a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "d2l-simple-overlay": "Brightspace/simple-overlay.git#semver:^3",
-    "d2l-table": "BrightspaceUI/table#semver:^2",
-    "polymer-cli": "^1.9.11"
+    "d2l-table": "BrightspaceUI/table#semver:^2"
   },
   "devDependencies": {
     "@polymer/iron-component-page": "^4.0.1",
@@ -36,6 +35,7 @@
     "gulp": "^4.0.2",
     "gulp-merge-json": "^1.3.1",
     "plop": "^2.4.0",
+    "polymer-cli": "^1.9.11",
     "rimraf": "^2.6.1",
     "wct-browser-legacy": "^1.0.2"
   },


### PR DESCRIPTION
We'd like for downstream projects to not need to install polymer-cli since it's a dev-only (built tool) dependency.